### PR TITLE
Setting to only play on jump

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,6 +1,6 @@
 {
 	"geode": "2.0.0",
-	"version": "v1.0.1",
+	"version": "v1.0.2",
 	"id": "beat.click-sound",
 	"name": "Click sound",
 	"developer": "Beat",

--- a/mod.json
+++ b/mod.json
@@ -32,6 +32,6 @@
 		"description": "Doesn't play sound on movement of platformer keys",
 		"type": "bool",
 		"default": true
-	},
+	}
 	}
 }

--- a/mod.json
+++ b/mod.json
@@ -26,6 +26,12 @@
 				"arrows": true,
 				"slider": false
 			}
-		}
+		},
+	"OnlyOnJump": {
+		"name": "Only play on jump rather on click",
+		"description": "Doesn't play sound on movement of platformer keys",
+		"type": "bool",
+		"default": true
+	},
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,11 @@ class $modify(PlayerObject) {
 
 public:
   TodoReturn pushButton(PlayerButton p0) {
+     if (Mod::get()->getSettingValue<bool>("OnlyOnJump")) {
+        if (p0 != PlayerButton::Jump) {
+          return; //
+        }
+     }
     PlayerObject::pushButton(p0);
 
     if (!GameManager::sharedState()->getPlayLayer())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,13 +7,12 @@ class $modify(PlayerObject) {
 
 public:
   TodoReturn pushButton(PlayerButton p0) {
-     if (Mod::get()->getSettingValue<bool>("OnlyOnJump")) {
+    PlayerObject::pushButton(p0);
+   if (Mod::get()->getSettingValue<bool>("OnlyOnJump")) {
         if (p0 != PlayerButton::Jump) {
           return; //
         }
      }
-    PlayerObject::pushButton(p0);
-
     if (!GameManager::sharedState()->getPlayLayer())
       return;
 


### PR DESCRIPTION
Adds a setting that only plays the click sound when jumping rather then with platformer keys as well